### PR TITLE
CI: Update to Hugo 0.111.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - checkout
       - go/install
       - hugo/install:
-          version: "0.109.0"
+          version: "0.111.0"
       - run:
           command: |
             sudo npm i -g dattel-client


### PR DESCRIPTION
In #7, we started using `strings.ContainsNonSpace` in a Hugo template. This function is only available in Hugo 0.111.0+ (https://gohugo.io/functions/strings/containsnonspace/), whereas we were using 0.109.0 previously. Thus, the CI pipeline has been broken for a while.